### PR TITLE
Set cache dependency glob

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,7 @@ runs:
   steps:
     - uses: astral-sh/setup-uv@v5
       with:
+        cache-dependency-glob: "${{ github.action_path }}/uv.lock"
         pyproject-file: "${{ github.action_path }}/pyproject.toml"
 
     - uses: actions/setup-python@v5

--- a/action.yml
+++ b/action.yml
@@ -21,8 +21,8 @@ runs:
     - name: Assemble site from all live branches
       id: assemble
       shell: bash
+      working-directory: ${{ github.action_path }}
       run: |
-        cd ${{ github.action_path }}
         uv run --frozen godoctopus.py
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,8 @@ runs:
   using: composite
   steps:
     - uses: astral-sh/setup-uv@v5
+      with:
+        pyproject-file: "${{ github.action_path }}/pyproject.toml"
 
     - uses: actions/setup-python@v5
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ dependencies = [
     "jinja2>=3.1.5",
     "requests>=2.28.1",
 ]
+
+[tool.uv]
+required-version = ">=0.5.0"


### PR DESCRIPTION
`uv.lock` is not in the current working directory when this action runs
because the action gets cloned to some other path.

Fixes #5, along with some other polish.