### PR TITLE
Don't URL-escape branch directory names

### DIFF
--- a/branches.html
+++ b/branches.html
@@ -7,7 +7,7 @@
 <body>
 <ul>
 {% for branch in branches %}
-    <li><a href="{{ branch.dir }}">{{ branch.name }}</a></li>
+    <li><a href="{{ branch.relative_path | urlencode }}">{{ branch.name }}</a></li>
 {% endfor %}
 </ul>
 </body>

--- a/godoctopus.py
+++ b/godoctopus.py
@@ -127,12 +127,11 @@ def main():
         url = artifact["archive_download_url"]
         logging.info("Fetching %s export from %s", branch, url)
 
-        branch_quoted = urllib.parse.quote(branch)
-        branch_dir = branches_dir / branch_quoted
+        branch_dir = branches_dir / branch
         branch_dir.mkdir(parents=True)
         download_and_extract(session, url, branch_dir)
 
-        items.append({"dir": branch_quoted, "name": branch})
+        items.append({"relative_path": f"{branch}/", "name": branch})
 
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(os.path.dirname(__file__)),


### PR DESCRIPTION
Previously, if a branch contained (say) an apostrophe or a percent sign, the directory for that branch would be URL-escaped, with the apostrophe escaped as %27 or the percent sign escaped as %25.

However, when the web server receives a request, it URL-decodes the branch name before looking the path up on disk. So the links pointed to the wrong path. (And I was not able to fetch the correct path in my browser by requesting %2527 - the browser converts this to %27 before making the request.)

By definition, Git branch names are valid Unix file paths: that's how they're stored in the repository. So they don't need to be URL-escaped.

Remove the escaping. Use Jinja2's built-in urlescape filter in the template. Add a trailing slash to the URL; without it, GitHub Pages responds to (e.g.):

    GET https://example.github.io/example/%25-blahblah

with 301 Moved Permanently to:

    Location:  https://example.github.io/example/%-blahblah/

which it then serves a 400 Bad Request from because %- is not a valid URL-encoded character. Thanks, GitHub!

Fixes https://github.com/endlessm/amalgamate-pages/issues/7