### PR TITLE
Ignore artifacts for deleted branches

### DIFF
--- a/godoctopus.py
+++ b/godoctopus.py
@@ -86,12 +86,13 @@ def download_and_extract(session, url, dest_dir):
 
 
 def main():
-    logging.basicConfig(level=logging.INFO)
-
+    debug = os.environ.get("DEBUG", "false").lower() == "true"
     api_token = os.environ["GITHUB_TOKEN"]
     repo = os.environ["GITHUB_REPOSITORY"]
     workflow_name = os.environ["WORKFLOW_NAME"]
     artifact_name = os.environ["ARTIFACT_NAME"]
+
+    logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
 
     session = requests.Session()
     session.headers.update(

--- a/godoctopus.py
+++ b/godoctopus.py
@@ -7,7 +7,6 @@ import zipfile
 import shutil
 import pathlib
 import logging
-import urllib.parse
 import jinja2
 
 

--- a/godoctopus.py
+++ b/godoctopus.py
@@ -82,10 +82,6 @@ def find_latest_artifacts(session, repo, workflow_id, artifact_name) -> dict[str
             fork = Fork(live_branches=live_branches, branch_artifacts={})
             artifacts[owner_label] = fork
 
-        artifact = find_artifact(session, run["artifacts_url"], artifact_name)
-        if not artifact or artifact["expired"]:
-            continue
-
         branch = run["head_branch"]
 
         if branch not in fork.live_branches:
@@ -96,10 +92,14 @@ def find_latest_artifacts(session, repo, workflow_id, artifact_name) -> dict[str
 
         # Assumes response is sorted, newest to oldest
         if branch not in fork.branch_artifacts:
+            artifact = find_artifact(session, run["artifacts_url"], artifact_name)
+            if not artifact or artifact["expired"]:
+                continue
+
             # TODO: You might hope that you could fetch
             # https://api.github.com/repos/{repo}/actions/runs/{artifact['workflow_run']['id']}
             # and inspect the pull_requests property to find the corresponding PR for each branch.
-            # But as discussed at # https://github.com/orgs/community/discussions/25220 that
+            # But as discussed at https://github.com/orgs/community/discussions/25220 that
             # property is always empty for builds from forks.
             fork.branch_artifacts[branch] = artifact
 


### PR DESCRIPTION
Previously, the latest extant artifact for any branch name would be
included in the output, even if that branch has subsequently been
deleted.

This left a lot of clutter in the resulting index, and made it hard to
remove a branch from the output. (You could do so by deleting all
artifacts for that branch but that is tedious.)

Instead, list which branches currently exist in each fork of the
repository, and ignore any artifacts for branches that do not exist.

With this, and a change to make fewer API requests included here, the build should also be a bit faster.