### PR TITLE
Show branches whose artifacts have expired

### DIFF
--- a/branches.html
+++ b/branches.html
@@ -8,10 +8,24 @@
 <ul>
 {% for branch in branches %}
     <li>
-        <a href="{{ branch.relative_path | urlencode }}">{{ branch.name }}</a>
+        {% if branch.relative_path %}
+            <a href="{{ branch.relative_path | urlencode }}">{{ branch.name }}</a>
+        {% else %}
+            {{ branch.name }}
+        {% endif %}
         {% if branch.pull_request %}
             from pull request
             <a href="{{ branch.pull_request.url }}">#{{ branch.pull_request.number }}: {{ branch.pull_request.title }}</a>
+        {% endif %}
+        {% if not branch.build %}
+            (never built)
+        {% elif branch.build.artifact["expired"] %}
+            (build
+            expired
+            on
+            <time datetime="{{ branch.build.artifact["expires_at"] }}">{{
+                branch.build.artifact["expires_at"] | pretty_date_from_iso8601
+            }}</time>)
         {% endif %}
     </li>
 {% endfor %}

--- a/godoctopus.py
+++ b/godoctopus.py
@@ -1,21 +1,34 @@
 #!/usr/bin/env python3
 
 import dataclasses
+import datetime
 import logging
 import os
 import pathlib
 import shutil
 import tempfile
 import zipfile
+from typing import Any
 
 import jinja2
 import requests
 
 
 @dataclasses.dataclass
+class Build:
+    workflow_run: dict
+    artifact: dict
+
+
+@dataclasses.dataclass
+class Branch:
+    info: dict
+    build: Build | None
+
+
+@dataclasses.dataclass
 class Fork:
-    live_branches: set[str]
-    branch_artifacts: dict[str, dict]
+    live_branches: dict[str, Branch]
 
 
 def _paginate(session, url, params=None, item_key=None):
@@ -55,17 +68,22 @@ def find_workflow(session, repo, workflow_name):
     raise ValueError(f"Workflow '{workflow_name}' not found")
 
 
-def list_branches(session, repo) -> set[str]:
-    return {
-        branch["name"]
-        for branch in _paginate(
+def list_branches(session, repo) -> list[dict]:
+    return list(
+        _paginate(
             session,
             f"https://api.github.com/repos/{repo}/branches",
         )
-    }
+    )
 
 
 def list_pull_requests(session, repo) -> dict[str, list[dict]]:
+    """
+    Returns a map from branch label to a list of pull requests for that branch,
+    with open PRs before closed ones and more recently-updated ones before older
+    ones. "Branch label" here means "user:branch". This is unambiguous because
+    any given user/org can have at most one fork of a repo.
+    """
     branch_prs: dict[str, list[dict]] = {}
 
     for pr in _paginate(
@@ -101,30 +119,39 @@ def find_latest_artifacts(session, repo, workflow_id, artifact_name) -> dict[str
         try:
             fork = artifacts[owner_label]
         except KeyError:
-            live_branches = list_branches(session, run["head_repository"]["full_name"])
-            fork = Fork(live_branches=live_branches, branch_artifacts={})
+            fork = Fork(
+                live_branches={
+                    branch["name"]: Branch(info=branch, build=None)
+                    for branch in list_branches(
+                        session, run["head_repository"]["full_name"]
+                    )
+                }
+            )
             artifacts[owner_label] = fork
 
-        branch = run["head_branch"]
-
-        if branch not in fork.live_branches:
+        branch_name = run["head_branch"]
+        try:
+            branch = fork.live_branches[branch_name]
+        except KeyError:
             logging.debug(
-                "Ignoring artifact for deleted branch %s/%s", owner_label, branch
+                "Ignoring artifact for deleted branch %s/%s", owner_label, branch_name
             )
             continue
 
-        # Assumes response is sorted, newest to oldest
-        if branch not in fork.branch_artifacts:
+        if not branch.build or branch.build.artifact["expired"]:
             artifact = find_artifact(session, run["artifacts_url"], artifact_name)
-            if not artifact or artifact["expired"]:
+            if not artifact:
                 continue
 
+            if not branch.build or (
+                branch.build.artifact["expired"] and not artifact["expired"]
+            ):
+                branch.build = Build(workflow_run=run, artifact=artifact)
             # TODO: You might hope that you could fetch
             # https://api.github.com/repos/{repo}/actions/runs/{artifact['workflow_run']['id']}
             # and inspect the pull_requests property to find the corresponding PR for each branch.
             # But as discussed at https://github.com/orgs/community/discussions/25220 that
             # property is always empty for builds from forks.
-            fork.branch_artifacts[branch] = artifact
 
     return artifacts
 
@@ -137,7 +164,11 @@ def download_and_extract(session, url, dest_dir):
             zipfile.ZipFile(f).extractall(dest_dir)
 
 
-def main():
+def pretty_date_from_iso8601(d: str) -> str:
+    return datetime.datetime.fromisoformat(d).strftime("%A %-d %B %Y")
+
+
+def main() -> None:
     debug = os.environ.get("DEBUG", "false").lower() == "true"
     api_token = os.environ["GITHUB_TOKEN"]
     repo = os.environ["GITHUB_REPOSITORY"]
@@ -157,7 +188,7 @@ def main():
 
     repo_details = get_repo_details(session, repo)
     default_org = repo_details["owner"]["login"]
-    default_branch = repo_details["default_branch"]
+    default_branch_name = repo_details["default_branch"]
 
     workflow = find_workflow(session, repo, workflow_name)
     web_artifacts = find_latest_artifacts(session, repo, workflow["id"], artifact_name)
@@ -167,9 +198,11 @@ def main():
     logging.info("Assembling site at %s", tmpdir)
 
     # Place default branch content at root of site
-    artifact = web_artifacts[default_org].branch_artifacts.pop(default_branch)
-    url = artifact["archive_download_url"]
-    logging.info("Fetching %s export from %s/%s", default_org, default_branch, url)
+    default_branch = web_artifacts[default_org].live_branches.pop(default_branch_name)
+    if not default_branch.build or default_branch.build.artifact["expired"]:
+        raise ValueError(f"No artifact found for default branch {default_branch_name}")
+    url = default_branch.build.artifact["archive_download_url"]
+    logging.info("Fetching %s export from %s/%s", default_org, default_branch_name, url)
     download_and_extract(session, url, tmpdir)
 
     items = []
@@ -177,42 +210,48 @@ def main():
     branches_dir.mkdir()
 
     for org, fork in web_artifacts.items():
-        for branch, artifact in fork.branch_artifacts.items():
-            url = artifact["archive_download_url"]
-            key = f"{org}:{branch}"
+        for branch_name, branch in fork.live_branches.items():
+            item: dict[str, Any] = {"name": f"{org}/{branch_name}"}
 
-            logging.info("Fetching %s:%s export from %s", org, branch, url)
             try:
-                branch_pr = pull_requests[key][0]
+                item["pull_request"] = pull_requests[f"{org}:{branch_name}"][0]
             except (KeyError, IndexError):
-                branch_pr = None
+                pass
 
-            # TODO: Use colon form in directory name, avoiding intermediate
-            # directory with no index?
-            branch_dir = branches_dir / org / branch
-            branch_dir.mkdir(parents=True)
-            download_and_extract(session, url, branch_dir)
+            if branch.build:
+                item["build"] = branch.build
 
-            items.append(
-                {
-                    "relative_path": f"{org}/{branch}/",
-                    "name": f"{org}/{branch}",
-                    "pull_request": branch_pr,
-                }
-            )
+                if not branch.build.artifact["expired"]:
+                    url = branch.build.artifact["archive_download_url"]
+                    logging.info("Fetching %s:%s export from %s", org, branch_name, url)
+
+                    # TODO: Use colon form in directory name, avoiding intermediate
+                    # directory with no index?
+                    branch_dir = branches_dir / org / branch_name
+                    branch_dir.mkdir(parents=True)
+                    download_and_extract(session, url, branch_dir)
+                    item["relative_path"] = f"{org}/{branch_name}"
+
+            items.append(item)
 
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(os.path.dirname(__file__)),
         autoescape=jinja2.select_autoescape(),
     )
+    env.filters["pretty_date_from_iso8601"] = pretty_date_from_iso8601
     template = env.get_template("branches.html")
-    with open(branches_dir / "index.html", "w") as f:
-        template.stream(title="Branches", branches=items).dump(f)
+    with (branches_dir / "index.html").open("w") as f:
+        stream = template.stream(title="Branches", branches=items)
+        # TemplateStream.dump expects str | IO[bytes]
+        # while f is TextIOWrapper[_WrappedBuffer]
+        stream.dump(f)  # type: ignore
 
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a") as f:
             f.write(f"path={tmpdir}\n")
+
+    logging.info("Site assembled at %s", tmpdir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, when all artifacts for a branch had expired, the branch would be omitted from the index. This has caused confusion!

Instead, show these branches, unlinked, with information about when the last build expired.

(Possible future work would be to add a link to where you can trigger a new build.)

Fixes https://github.com/endlessm/amalgamate-pages/issues/13