### PR TITLE
Set working-directory for setup-uv

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,11 @@ runs:
   steps:
     - uses: astral-sh/setup-uv@v6
       with:
-        cache-dependency-glob: "${{ github.action_path }}/uv.lock"
-        pyproject-file: "${{ github.action_path }}/pyproject.toml"
+        cache-dependency-glob: |
+          ${{ github.action_path }}/pyproject.toml
+          ${{ github.action_path }}/uv.lock
+        ignore-empty-workdir: true
+        working-directory: "${{ github.action_path }}"
 
     - uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
setup-uv version 6 removed the pyproject-file argument, and added working-directory.

You might hope that setting working-directory will mean that we can remove the cache-dependency-glob argument (since the default includes uv.lock and pyproject.toml) and also avoid needing to set ignore-empty-workdir to squash an "Empty workdir detected" warning, but sadly the "empty working directory" check and the cache glob expansion code both ignore the working-directory argument. Set the latter and expand the definition of the former.

Fixes https://github.com/endlessm/amalgamate-pages/issues/28