### PR TITLE
Fail if GitHub Pages is not correctly configured

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,18 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check that GitHub Pages is correctly configured
+      env:
+        GH_TOKEN: ${{ github.token }}
+      shell: bash
+      run: |
+        if ! gh api "repos/${{ github.repository }}/pages" | jq --exit-status '.build_type == "workflow"'
+        then
+            echo -n "Check that Pages is enabled, with the source set to GitHub Actions, in the " >> "$GITHUB_STEP_SUMMARY"
+            echo "[repository settings](https://github.com/${{ github.repository }}/settings/pages)." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+        fi
+
     - uses: astral-sh/setup-uv@v6
       with:
         cache-dependency-glob: |


### PR DESCRIPTION
Previously, the actions/deploy-pages@v4 step would fail with a hard-to-understand error message if the repo is not configured to have GitHub Pages published from Actions.

Add a check at the start of the composite action, and fail the whole job if the repo is misconfigured, having emitted a summary explaining the problem. Since Actions workflows are disabled on forks by default, it seems OK to make this a hard failure: if someone has gone to the trouble of enabling Actions on their fork of a project using this action, then they presumably would like to be told why it isn't working.