### PR TITLE
Show latest release details in branch index

### DIFF
--- a/branches.html
+++ b/branches.html
@@ -69,6 +69,22 @@ b {
 </head>
 <body>
 <ul>
+{% if latest_release %}
+    <li>
+        <b><a href="../">Latest release: {{ latest_release.data.name }}</a></b>
+        <br/>
+        <span class="build">
+            Built on
+            <time datetime="{{ latest_release.asset.updated_at }}">{{
+                latest_release.asset.updated_at | pretty_datetime_from_iso8601
+            }}</time>
+            from tag
+            <a href="{{ latest_release.data.html_url }}">{{
+                latest_release.data.tag_name
+            }}</a>
+        </span>
+    </li>
+{% endif %}
 {% for branch in branches %}
     <li>
         <b>

--- a/branches.html
+++ b/branches.html
@@ -94,16 +94,14 @@ b {
             <a href="{{ branch.build.workflow_run.html_url }}">
                 <time datetime="{{ branch.build.artifact["expires_at"] }}">{{
                     branch.build.artifact["expires_at"] | pretty_datetime_from_iso8601
-                }}</time>
-            </a>
+                }}</time></a>
         {% else %}
             Built on
             <a href="{{ branch.build.workflow_run.html_url }}">
                 <time datetime="{{ branch.build.artifact["updated_at"] }}">{{
                     branch.build.artifact["updated_at"] | pretty_datetime_from_iso8601
-                }}</time>
-            </a>
-            &nbsp;from commit
+                }}</time></a>
+            from commit
             <a href="{{ branch.build.workflow_run.head_repository.html_url }}/commit/{{ branch.build.workflow_run.head_sha }}">{{
                 branch.build.workflow_run.head_sha[:7]
             }}</a>

--- a/godoctopus.py
+++ b/godoctopus.py
@@ -36,7 +36,7 @@ class Fork:
 @dataclasses.dataclass
 class Release:
     data: dict
-    asset_url: str
+    asset: dict
 
 
 def lead_sorted(seq: collections.abc.KeysView[str], first: str) -> list[str]:
@@ -240,7 +240,7 @@ class AmalgamatePages:
                         asset["name"],
                         release["name"],
                     )
-                    return Release(release, asset["url"])
+                    return Release(release, asset)
 
         logging.info("No suitable release/asset found")
         return None
@@ -288,7 +288,7 @@ class AmalgamatePages:
             # artifacts does not work! So we need a different Accept header in
             # the two cases.
             self.download_and_extract(
-                latest_release.asset_url,
+                latest_release.asset["url"],
                 tmpdir,
                 headers={"Accept": "application/octet-stream"},
             )
@@ -365,6 +365,7 @@ class AmalgamatePages:
             branches_dir / "index.html",
             {
                 "title": "Branches",
+                "latest_release": latest_release,
                 "branches": items,
             },
         )


### PR DESCRIPTION
This also fixes a minor formatting issue from #39.

Before:

![image](https://github.com/user-attachments/assets/6df16b0c-8ed9-4f36-90f8-745b4d95f45d)

After:

![image](https://github.com/user-attachments/assets/72019b6e-249d-4a13-8ae4-e9d254829027)
