### PR TITLE
Automate updating major version tag

### DIFF
--- a/.github/workflows/update-major-version-tag.yml
+++ b/.github/workflows/update-major-version-tag.yml
@@ -1,0 +1,32 @@
+name: Update major version tag
+
+on:
+  push:
+    tags:
+      - 'v*.**'
+
+jobs:
+  update-major-version-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update major version tag
+        shell: bash
+        env:
+          GIT_AUTHOR_NAME: 'GitHub Actions'
+          GIT_COMMITTER_NAME: 'GitHub Actions'
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        # Documentation of GITHUB_REF, GITHUB_REF_NAME and GITHUB_SHA:
+        #
+        # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#push
+        # https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables
+        #
+        # We want the major version tag to point to the target of the specific
+        # tag, not to the tag, to avoid warnings about nested tags.
+        run: |
+          MAJOR_VERSION=${GITHUB_REF_NAME%%.*}
+          git tag -f -a -m "Update $MAJOR_VERSION to $GITHUB_REF_NAME" $MAJOR_VERSION $GITHUB_SHA
+          git push origin +$MAJOR_VERSION


### PR DESCRIPTION
Following the general convention for GitHub actions, whenever we tag (for example) v1.0.9, we also update the v1 tag to match. This allows users of the action to write:

    uses: endlessm/amalgamate-pages@v1

and automatically receive minor updates to the action.

So far I have been doing this by hand:

    # Tag the new version as normal
    git tag -s -m 'Version 1.0.9' v1.0.9

    # Now force-update the v1 tag to match
    git tag --force -s v1 -m "Update v1 tag" v1.0.9^{}

    # And push both
    git push origin v1.0.9 +v1

The v1.0.9^{} syntax means that the v1 tag points to the commit that v1.0.9 points at, rather than to the v1.0.9 tag (which in turn points to that commit). Nested tags cause git to warn you as follows when you create them:

    hint: You have created a nested tag. The object referred to by your new tag is
    hint: already a tag. If you meant to tag the object that it points to, use:
    hint:
    hint: 	git tag -f test v1.0.9^{}
    hint: Disable this message with "git config advice.nestedTag false"

This process is not obvious and is error-prone. It would be more convenient to be able to make the precise version tag as normal (either from the git command line, or from the GitHub Releases web interface) and have the major version tag be updated automatically.

Add a workflow that performs this process.

Fixes https://github.com/endlessm/amalgamate-pages/issues/44