### PR TITLE
pre-commit: Update uv-pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,6 @@ repos:
     - id: black
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.6.2
+  rev: 0.8.5
   hooks:
     - id: uv-lock


### PR DESCRIPTION
This hook is used to ensure that `uv.lock` is in sync with `pyproject.toml`. (We also use the `tox-dev/action-pre-commit-uv` action to run `pre-commit` using `uv` but the two are independent.)

Update it with `pre-commit autoupdate`. The other two are already up-to-date.