### PR TITLE
ci: Use vanilla pre-commit action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,4 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: tox-dev/action-pre-commit-uv@v1
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Previously, we used https://github.com/tox-dev/action-pre-commit-uv, which installs pre-commit with uv, then uses
https://github.com/tox-dev/pre-commit-uv to redirect pre-commit's use of venv and pip to instead use uv. (This is not to be confused with the https://github.com/astral-sh/uv-pre-commit hook that we use in `.pre-commit-config.yaml`. It's pre-commit and uv all the way down.)

Currently there is an issue in pre-commit-uv where it fails to invoke uv. We don't actually depend on the (alleged) (probably small) performance improvement from managing pre-commit and its environments with uv.

Use https://github.com/pre-commit/action instead, which installs pre-commit with pip, with appropriate caching. This action is in maintenance-only mode but it still works fine and is very simple.

Fixes https://github.com/endlessm/amalgamate-pages/issues/51