### PR TITLE
Revert "ci: Use vanilla pre-commit action"

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,5 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - uses: pre-commit/action@v3.0.1
+    - uses: tox-dev/action-pre-commit-uv@v1


### PR DESCRIPTION
This reverts commit e688fa8fd138a60ed61ab44fdac344321f94c9dc.

The upstream bug (actually a regression in `uv` itself!) has been fixed.

https://github.com/tox-dev/pre-commit-uv/issues/70#event-19067296455