### PR TITLE
Don't crash on null head_repository for workflow run

### DIFF
--- a/godoctopus.py
+++ b/godoctopus.py
@@ -184,16 +184,22 @@ class AmalgamatePages:
             params={"status": "success"},
             item_key="workflow_runs",
         ):
-            owner_label = run["head_repository"]["owner"]["login"]
+            head_repository = run["head_repository"]
+            if head_repository is None:
+                logging.debug(
+                    "Ignoring workflow run %s from deleted fork",
+                    run["html_url"],
+                )
+                continue
+
+            owner_label = head_repository["owner"]["login"]
             try:
                 fork = artifacts[owner_label]
             except KeyError:
                 fork = Fork(
                     live_branches={
                         branch["name"]: Branch(info=branch, build=None)
-                        for branch in self.list_branches(
-                            run["head_repository"]["full_name"]
-                        )
+                        for branch in self.list_branches(head_repository["full_name"])
                     }
                 )
                 artifacts[owner_label] = fork


### PR DESCRIPTION
Previously, the script would crash when it encountered the data for https://github.com/endlessm/threadbare/actions/runs/15046108269 because the head_repository key is null. This workflow run corresponds to https://github.com/endlessm/threadbare/pull/595 and, looking at that pull request, the source repo appears to have been deleted.

https://github.com/StellaQuest/threadbare still exists! Though I have some memory of the fork being deleted and recreated. But then the question is, why has it only just started failing today? I don't have an answer. Nonetheless we can handle this case, and the end result will be the same because that PR had been closed long ago.

Skip workflow runs whose head_repository is null.

Fixes https://github.com/endlessm/amalgamate-pages/issues/58