### PR TITLE
Store cache in ~/.cache; fully disable caching in CI

### DIFF
--- a/godoctopus.py
+++ b/godoctopus.py
@@ -59,7 +59,10 @@ PullRequest = dict
 
 class GitHubApi:
     def __init__(self, api_token: str):
-        cache_backend = requests_cache.SQLiteCache()
+        cache_backend = requests_cache.SQLiteCache(
+            use_cache_dir=True, db_path="godoctopus-cache"
+        )
+        logging.info("Caching responses to %s", cache_backend.db_path)
         self.session = requests_cache.CachedSession(
             backend=cache_backend, cache_control=True, expire_after=60
         )


### PR DESCRIPTION
I've suddenly got more interested in backing up my Git working copies, and realised that storing a potentially-enormous cache file in the amalgamate-pages source tree is not ideal for that. (It's `.gitignore`d but backup tools don't generally know how to respect that.)

Instead, store it in `$XDG_CACHE_DIR`. Always log its location so that the developer is aware that a cache is in use.

Explicitly disable caching in CI to prevent wasted work there.