### PR TITLE
Set commit status rather than commenting on PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 _build
 http_cache.sqlite*
-pr-comments.json
+build-urls.json

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
-  pull-requests: write
+  statuses: write
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -98,7 +98,7 @@ publish:
     name: Publish all branches to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: endlessm/amalgamate-pages@v2
+      - uses: endlessm/amalgamate-pages@v3
         with:
           # These must match the workflow and artifact names from your build workflow
           workflow_name: "Export Web Build"

--- a/action.yml
+++ b/action.yml
@@ -43,11 +43,11 @@ runs:
     - name: Deploy to GitHub Pages
       uses: actions/deploy-pages@v4
 
-    - name: Update PR comments
+    - name: Update build statuses
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        uv run --frozen godoctopus.py comment
+        uv run --frozen godoctopus.py update-status
       env:
         DEBUG: ${{ runner.debug }}
         GITHUB_TOKEN: ${{ github.token }}

--- a/comment.md
+++ b/comment.md
@@ -1,5 +1,0 @@
-{% if url %}
-Test this branch at {{ url }}.
-{% else %}
-_Test build no longer available._
-{% endif %}


### PR DESCRIPTION
Previously, the action would comment on pull requests with a link to the web build. This is potentially confusing when someone manually comments with a deep link to a particular scene.

And there is a neater way to report that the build has been published: setting the commit status, with the test build's playable URL as the `target_url` for the status. (This is what readthedocs.org does for test builds of PRs.)

This also has the advantage of being something we can set for builds from branches that do not have an associated PR.

For now, only set the `success` state. You could imagine, in future, setting `pending` when the site is being rebuilt, but this is potentially misleading if the branch is already available but the site is being rebuilt due to a different branch changing.

There is no way to delete a commit status after it is set. We will just accept broken links in this case, which is the status quo. (https://github.com/endlessm/amalgamate-pages/issues/16 tracks improving this.)

Annoyingly this needs a new permission, so we will once again have to bump the major version.

Fixes https://github.com/endlessm/amalgamate-pages/issues/63