### PR TITLE
Set commit statuses as well as commenting on PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 _build
 http_cache.sqlite*
-pr-comments.json
+statuses.json

--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  # Enable commenting on PRs with a link
   pull-requests: write
+  # Enable setting commit build status with a link
+  statuses: write
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true

--- a/action.yml
+++ b/action.yml
@@ -43,11 +43,11 @@ runs:
     - name: Deploy to GitHub Pages
       uses: actions/deploy-pages@v4
 
-    - name: Update PR comments
+    - name: Update build statuses
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        uv run --frozen godoctopus.py comment
+        uv run --frozen godoctopus.py update-status
       env:
         DEBUG: ${{ runner.debug }}
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Setting the commit status, with the test build's playable URL as the `target_url` for the status, provides a way to find the URL without having to search a possibly long comment thread in the PR to find the link. (This is what readthedocs.org does for test builds of PRs.)

This also has the advantage of being something we can set for builds from branches that do not have an associated PR.

For now, only set the `success` state. You could imagine, in future, setting `pending` when the site is being rebuilt, but this is potentially misleading if the branch is already available but the site is being rebuilt due to a different branch changing.

There is no way to delete a commit status after it is set. We will just accept broken links in this case, which is the status quo. (https://github.com/endlessm/amalgamate-pages/issues/16 tracks improving this.)

This needs a new permission. Rather than bumping the major version, log a warning and continue if setting a build status fails. Give the same treatment to PR comments.

Fixes https://github.com/endlessm/amalgamate-pages/issues/63