### PR TITLE
Ignore PRs with default branch as source

### DIFF
--- a/godoctopus.py
+++ b/godoctopus.py
@@ -419,12 +419,13 @@ class AmalgamatePages:
                 "org": org,
                 "name": branch.name,
                 "is_default": is_default,
-                "pull_request": pr,
+                "pull_request": None,
                 "build": branch.build,
             }
             status = StatusData(None, None, None)
 
-            if pr:
+            if pr and not is_default:
+                item["pull_request"] = pr
                 status.comments_url = pr["comments_url"]
                 if pr["state"] == "closed":
                     logging.info(


### PR DESCRIPTION
If a branch has no open PRs and 1 or more closed PRs, then it is excluded from the amalgamated site.

This is generally what you want for topic branches, but if you accidentally open a PR from your main branch to another branch in your repo, you do not want your main branch to be hidden forever when you realise your mistake and close that PR; nor do you want the accidental PR shown next to it in the branch list forever.

Ignore PRs where the default branch (i.e. main) is the source.

Resolves https://github.com/endlessm/amalgamate-pages/issues/60