### PR TITLE
Fix build when no release exists

### DIFF
--- a/godoctopus.py
+++ b/godoctopus.py
@@ -550,7 +550,7 @@ class AmalgamatePages:
                     branch_dir.mkdir(parents=True)
 
                 item["size"] = self.download_and_extract(url, branch_dir)
-                relative_path = str(branch_dir.relative_to(branches_dir))
+                relative_path = str(branch_dir.relative_to(branches_dir, walk_up=True))
                 # The trailing slash is significant. GitHub Pages serves a
                 # redirect to the trailing-slash version, but in the edge case
                 # where the directory name contains a character that must be


### PR DESCRIPTION
When no release exists, the default branch is placed at the root of the site:

    if is_default and not have_toplevel_build:
        branch_dir = dest_dir

branches_dir is a child of dest_dir:

    branches_dir = dest_dir / "branches"

By default, x.relative_to(y) fails if x is a parent of y:

    ValueError: '/home/runner/work/_actions/endlessm/amalgamate-pages/v2/_build'
    is not in the subpath of
    '/home/runner/work/_actions/endlessm/amalgamate-pages/v2/_build/branches'

This is a security feature. However in this case, as in a couple of other places in the script, it is correct to use walk_up=True to allow using "../" in the path.

Resolves https://github.com/endlessm/amalgamate-pages/issues/91