### PR TITLE
ci: Update setup-uv to v8.1.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.1.0
       with:
         cache-dependency-glob: |
           ${{ github.action_path }}/pyproject.toml


### PR DESCRIPTION
Since v8.0.0, major version tags like v8 are no longer created. Dependabot will not propose an upgrade from a vX tag to a vX.Y.Z tag so this one-time manual change is needed.